### PR TITLE
Move to JDK 21 and cfparser 2.15.2-SNAPSHOT

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 21
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
     - name: Build with Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
       - name: Configure Maven for GitHub Packages
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(21)
         vendor = JvmVendorSpec.ADOPTIUM
     }
     

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ repositories {
     }
 }
 dependencies {
-    implementation 'com.github.cfmleditor:cfml.parsing:2.15.0-SNAPSHOT'
+    implementation 'com.github.cfmleditor:cfml.parsing:2.15.2-SNAPSHOT'
     implementation 'commons-cli:commons-cli:1.2'
     implementation 'ro.fortsoft.pf4j:pf4j:0.6'
     implementation 'org.apache.ant:ant:1.10.14'

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.proc>none</maven.compiler.proc>
 
-		<cfparser.version>2.15.0-SNAPSHOT</cfparser.version>
+		<cfparser.version>2.15.2-SNAPSHOT</cfparser.version>
 		<jackson.version>2.18.6</jackson.version>
 		<slf4j.version>1.7.21</slf4j.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.proc>none</maven.compiler.proc>
 
 		<cfparser.version>2.15.2-SNAPSHOT</cfparser.version>


### PR DESCRIPTION
Picks up the expression and dictionary caching work in cfparser, and moves this build to JDK 21 to match cfparser's new baseline.

The two changes ship together because they are not separable: cfparser now compiles at Java 21, so its artifacts are class file version 65 and cannot be loaded by an 11 JVM. Bumping the dependency without moving the JDK would fail at runtime with `UnsupportedClassVersionError`.

## Changes

| File | Change |
|---|---|
| `pom.xml:84` | `cfparser.version` 2.15.0-SNAPSHOT → 2.15.2-SNAPSHOT |
| `build.gradle:121` | same version, declared separately here |
| `pom.xml:80-81` | `maven.compiler.source`/`target` 11 → 21 |
| `build.gradle:40` | toolchain `languageVersion` 11 → 21 |
| `gradle.yml`, `publish.yml` | runner JDK 11 → 21 |

`native-release.yml` already uses JDK 25 and is unaffected.

## It also fixes CI, which was already red

The Gradle workflow has been failing on `master` since 6 July, unrelated to this change: the wrapper was upgraded to Gradle 9.6.1, which requires JVM 17+ to run, while the workflow kept supplying JDK 11.

```
Gradle requires JVM 17 or later to run. Your build is currently configured to use JVM 11.
```

Moving to 21 satisfies that and the new cfparser baseline at once. Worth knowing when reading this PR's earlier red runs — they were inherited from the base branch, not caused here.

## The version is declared twice

`pom.xml` uses a `cfparser.version` property; `build.gradle` hardcodes the coordinate. Both are updated. A Maven-only bump would leave Gradle resolving the old artifact.

That duplication is the same shape of drift that needed three separate fixes in cfparser today, where the Maven and Gradle builds declared different versions for five months. Extracting the Gradle value into a shared property would remove the failure mode — left out here to keep this PR to its purpose.

## Verification

- `mvn clean test` — **675 tests, 0 failures**, 4 pre-existing skips, at Java 21 against cfparser 2.15.2-SNAPSHOT.
- The Gradle build could not be exercised locally: the toolchain pins `JvmVendorSpec.ADOPTIUM` and this environment has a non-Temurin JDK 21 with no route to the foojay resolver. CI's `setup-java` supplies `temurin` 21 and satisfies the pin, so that half is verified by this PR's run rather than by me.

## Ordering

cfparser `2.15.2-SNAPSHOT` is currently published as **Java 11** bytecode — it was built before the baseline change merged. It needs republishing from cfparser `master` (Actions → Maven Package → Run workflow) before this PR's CI reflects the real artifact. Until then CI here builds against the older Java 11 jar, which will still pass, but is not what will ship.

## What lands in CFLint

| cfparser PR | Effect here |
|---|---|
| #4 | parse-tree cache on `parseCFMLExpression`, which CFLint calls at five sites |
| #5 | syntax errors reported on every occurrence — previously a repeated broken expression was linted once and silently skipped thereafter |
| #9 | cache limit raised to 2000, above the 1,786 distinct expressions measured in a real source file |
| #12 | Java 21 baseline |

Measured separately: a cache hit costs ~7% of a miss, worth roughly 30% of expression-parsing time on a large file. `parseScript`, tag scanning and plugins are unaffected, so the whole-scan improvement is smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35