### PR TITLE
Update CLAUDE.md for the Java 21 baseline and add a bump-cfparser skill

### DIFF
--- a/.claude/skills/bump-cfparser/SKILL.md
+++ b/.claude/skills/bump-cfparser/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: bump-cfparser
+description: Upgrade CFLint's cfparser (cfml.parsing) dependency to a new version and verify it actually took effect. Use this whenever someone wants to pick up parser changes, a grammar fix, or new cfparser behaviour, whenever a cfparser bug was fixed upstream and needs pulling in, and whenever a parser-level fix "isn't working" in CFLint — that is usually an unpublished artifact, a half-applied bump, or a cached SNAPSHOT rather than a real bug.
+---
+
+# Bumping the cfparser dependency
+
+This looks like a one-line change and is not. Three separate things make a bump appear to work
+while CFLint still runs the old parser.
+
+## 1. The version is declared twice
+
+Both must change:
+
+| File | Form |
+|---|---|
+| `pom.xml` | `<cfparser.version>X.Y.Z-SNAPSHOT</cfparser.version>` property |
+| `build.gradle` | hardcoded `implementation 'com.github.cfmleditor:cfml.parsing:X.Y.Z-SNAPSHOT'` |
+
+Gradle is the primary build and what CI runs, so a Maven-only bump is the worse half to miss —
+tests pass locally under Maven while CI keeps compiling against the old artifact.
+
+Confirm both moved:
+
+```bash
+grep -rn "cfml\.parsing\|cfparser\.version" pom.xml build.gradle
+```
+
+## 2. The new version has to actually exist
+
+cfparser publishes to GitHub Packages **only** on a tag push, a release, or a manual workflow
+dispatch — never on merge to `master`. A fix merged upstream is not automatically available here.
+
+Before bumping, confirm the coordinate was really published: check that cfparser's *Maven Package*
+workflow ran green for that version, not merely that the commit is on `master`. A tag existing is
+not sufficient either — a publish run can fail after the tag is created, leaving a version that
+looks released and was never uploaded.
+
+If it has not been published, the bump will fail to resolve, and the honest move is to say so and
+get it published first rather than pinning something unresolvable.
+
+## 3. Check the Java baseline moved too
+
+cfparser and CFLint must stay on the same Java baseline. If cfparser raised its `maven.compiler.release`,
+CFLint's artifacts cannot load the newer class file version and will fail at runtime with
+`UnsupportedClassVersionError` — even though compilation succeeds, because `javac` happily reads
+class files newer than its own `-target`.
+
+Four places carry the Java version here:
+
+- `pom.xml` — `maven.compiler.source` / `maven.compiler.target`
+- `build.gradle` — toolchain `languageVersion`
+- `.github/workflows/gradle.yml` and `publish.yml` — runner `java-version`
+
+`native-release.yml` runs a newer JDK for GraalVM and is usually already ahead.
+
+## 4. Verify
+
+```bash
+mvn clean test        # 675 tests
+./gradlew build
+```
+
+Prefer `mvn clean test` when checking a fresh upstream artifact. It resolves independently of
+Gradle's cache and gives a trustworthy answer.
+
+The Gradle build may not run in every environment: the toolchain pins `JvmVendorSpec.ADOPTIUM`, so
+a non-Temurin JDK fails unless the foojay resolver can download one. That is an environment
+limitation, not a defect — say so rather than reporting the change as broken.
+
+## 5. Do not trust a green CI run too quickly
+
+Gradle treats `-SNAPSHOT` as a changing module and caches it for **24 hours**, and the workflows
+restore a Gradle cache. A CI run started shortly after an upstream republish can compile against
+the previous artifact and pass, telling you nothing about the version you just pinned.
+
+Ways to get a trustworthy answer:
+
+- A push-triggered run on a different branch, whose cache key differs
+- A Maven-resolved build
+- Simply waiting out the 24-hour window
+
+When reporting results, distinguish "CI is green" from "CI exercised the new artifact". They are
+often not the same claim, and conflating them has hidden a stale dependency here before.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ CFLint is a static code analysis tool for CFML (ColdFusion Markup Language). It 
 
 ## Build & test commands
 
-Gradle is the primary build (Maven is deprecated but still present via `pom.xml`). Requires Java 11+ (toolchain pinned to 11; GraalVM native build needs GraalVM 25, see below).
+Gradle is the primary build (Maven is deprecated but still present via `pom.xml`). Requires Java 21+ (toolchain pinned to 21; GraalVM native build needs GraalVM 25, see below).
+
+The baseline moved from 11 to 21 in 2026-08, forced by upstream: cfparser now compiles at Java 21, and class file version 65 cannot be loaded by an 11 JVM. Four places had to move together — `maven.compiler.source`/`target` in `pom.xml`, the toolchain `languageVersion` in `build.gradle`, and the runner `java-version` in both `gradle.yml` and `publish.yml`. `native-release.yml` was already on 25 and needed nothing.
 
 ```bash
 ./gradlew build              # compile + test + jar
@@ -124,4 +126,13 @@ Benchmarked against a real 5,235-file CFML codebase (`-folder` scan) in 2026-07:
 
 ### Dependency note
 
-CFLint depends on `com.github.cfmleditor:cfml.parsing` (a fork of CFParser) for CFML tokenizing/parsing and ANTLR-generated cfscript grammar (`cfml.CFSCRIPTLexer`/`CFSCRIPTParser`). Most parser-level bugs (bad tokenization, grammar gaps) live upstream in that dependency, not in this repo — check there first if a rule seems to receive a malformed tree. On this machine a source checkout of that upstream project (including `cfml.dictionary`, the tag/attribute definition XML consumed by `CFMLTagInfo`) exists at `~/development/github/cfparser` — useful for reading tag definitions directly rather than guessing from the published jar, though CFLint's `build.gradle` pulls a released artifact, not this local source.
+CFLint depends on `com.github.cfmleditor:cfml.parsing` (a fork of CFParser) for CFML tokenizing/parsing and ANTLR-generated cfscript grammar (`cfml.CFSCRIPTLexer`/`CFSCRIPTParser`). Most parser-level bugs (bad tokenization, grammar gaps) live upstream in that dependency, not in this repo — check there first if a rule seems to receive a malformed tree.
+
+**The version is declared twice** and both must move together: a `cfparser.version` property in `pom.xml`, and a hardcoded coordinate in `build.gradle`'s `dependencies` block. A Maven-only bump leaves the Gradle build — which is the primary build and what CI runs — silently resolving the old artifact. See the `bump-cfparser` skill.
+
+Two things make a bump look like it worked when it did not:
+
+- **Merging upstream publishes nothing.** cfparser only deploys to GitHub Packages on a tag push, a release, or a manual workflow dispatch, so a fix merged to cfparser `master` stays invisible here until someone publishes it. A pin was stuck on a five-month-stale `2.15.0-SNAPSHOT` this way, and the intervening `2.15.1-SNAPSHOT` had a *failed* publish run, so that coordinate never carried the code its tag suggested.
+- **Gradle caches `-SNAPSHOT` modules for 24 hours**, and the workflows restore a Gradle cache. A green CI run shortly after an upstream republish may well have compiled against the previous artifact. Confirm through a branch whose cache key differs, or resolve via Maven.
+
+Worth knowing about the parser API: `parseCFMLExpression` caches parse trees and is what this repo calls (five sites in `CFLint.java`); cfparser's own tag traversal uses the uncached `parseCFExpression`, so upstream benchmarks of "the cache" may not describe this code path. `fireStartedProcessing` constructs a fresh `CFMLParser` per file, so that cache is per-file and never accumulates across a scan. On this machine a source checkout of that upstream project (including `cfml.dictionary`, the tag/attribute definition XML consumed by `CFMLTagInfo`) exists at `~/development/github/cfparser` — useful for reading tag definitions directly rather than guessing from the published jar, though CFLint's `build.gradle` pulls a released artifact, not this local source.


### PR DESCRIPTION
Documentation follow-up to #53. This repo already had a detailed `CLAUDE.md`, so this **edits it in place** rather than replacing it — the architecture, plugin, config and performance sections are untouched.

## The stale part

The build section said *"Requires Java 11+ (toolchain pinned to 11)"*. That stopped being true when #53 moved the baseline to 21 to follow cfparser. Now corrected, with a note on why it moved and which **four** places carry the Java version, since they have to move together:

- `pom.xml` — `maven.compiler.source`/`target`
- `build.gradle` — toolchain `languageVersion`
- `gradle.yml` and `publish.yml` — runner `java-version`

(`native-release.yml` was already on 25.)

## The dependency note, expanded

Three things make a cfparser bump look successful when it is not, all hit during this work:

1. **The version is declared twice** — a `cfparser.version` property in `pom.xml` and a hardcoded coordinate in `build.gradle`. Missing the Gradle one is the worse half, since Gradle is the primary build and what CI runs: Maven tests pass locally while CI keeps compiling the old artifact.
2. **Merging upstream publishes nothing.** cfparser deploys only on tag push, release, or manual dispatch. The pin here sat on a five-month-stale `2.15.0-SNAPSHOT` because of it — and the intervening `2.15.1-SNAPSHOT` had a *failed* publish run, so that coordinate never carried the code its tag implied.
3. **Gradle caches `-SNAPSHOT` for 24 hours**, and the workflows restore a Gradle cache. A green run shortly after an upstream republish may have compiled the previous artifact.

Also recorded: `parseCFMLExpression` is the cached entry point this repo calls at five sites, while cfparser's own traversal uses the uncached `parseCFExpression` — so upstream statements about "the cache" don't automatically describe this code path. And `fireStartedProcessing` builds a fresh `CFMLParser` per file, making that cache per-file.

## New skill: `bump-cfparser`

`.claude/skills/bump-cfparser/SKILL.md` walks the upgrade end to end: both declaration sites, confirming the upstream artifact was really published (a tag can exist while its publish run failed), keeping the Java baselines aligned, and verifying.

It closes on the distinction that caused the most confusion here — telling **"CI is green"** apart from **"CI exercised the new artifact"**. Those are different claims, and conflating them hid a stale dependency.

The skill also notes that the Gradle build can't run in every environment, since the toolchain pins `JvmVendorSpec.ADOPTIUM` — an environment limitation to report as such rather than as a broken change.

## Scope

Docs only. No source, build config, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_