### PR TITLE
Refine the bump-cfparser skill with two diagnostics from evaluation runs

### DIFF
--- a/.claude/skills/bump-cfparser/SKILL.md
+++ b/.claude/skills/bump-cfparser/SKILL.md
@@ -26,6 +26,14 @@ Confirm both moved:
 grep -rn "cfml\.parsing\|cfparser\.version" pom.xml build.gradle
 ```
 
+Grep the full coordinate rather than a bare version number. `commons-io:2.15.1` in `build.gradle`
+matches a naive `2\.15\.` search and is unrelated, and the tracked `pom.xml.versionsBackup` still
+pins a long-dead `2.6.0` under the old `com.github.cfparser` groupId — no build reads it, but it
+is a decoy every time someone greps for versions here.
+
+`CHANGELOG.md` needs no edit: it is generated from git history by the `gitChangelog` Gradle task,
+so a hand-written entry is overwritten on the next run.
+
 ## 2. The new version has to actually exist
 
 cfparser publishes to GitHub Packages **only** on a tag push, a release, or a manual workflow
@@ -63,6 +71,22 @@ mvn clean test        # 675 tests
 
 Prefer `mvn clean test` when checking a fresh upstream artifact. It resolves independently of
 Gradle's cache and gives a trustworthy answer.
+
+**Read a resolution failure carefully — it probably names the wrong repository.** The
+`allow-snapshots` profile in `pom.xml` is `activeByDefault` and adds Sonatype's snapshot
+repository, which Maven tries *before* the `github` repository that actually hosts cfparser. So an
+artifact that simply has not been published yet surfaces as a Sonatype error, and a network or
+proxy problem surfaces the same way. Neither message means what it appears to.
+
+To tell "not published" apart from "cannot reach the repository", re-resolve pinning a version you
+know exists:
+
+```bash
+mvn dependency:get -Dartifact=com.github.cfmleditor:cfml.parsing:2.15.2-SNAPSHOT
+```
+
+If the known-good version fails identically, the environment is the problem and the run says
+nothing about publication — go back to checking the upstream workflow run instead.
 
 The Gradle build may not run in every environment: the toolchain pins `JvmVendorSpec.ADOPTIUM`, so
 a non-Temurin JDK fails unless the foojay resolver can download one. That is an environment


### PR DESCRIPTION
Companion to cfmleditor/cfparser#21. Adds what nine sandboxed evaluation runs proved was missing from this skill, and nothing else.

## A resolution failure names the wrong repository

The most useful finding, and one that would mislead anyone debugging a failed bump.

The `allow-snapshots` profile in `pom.xml:315` is `activeByDefault` and adds Sonatype's snapshot repository. Maven tries it **before** the `github` repository that actually hosts cfparser. So:

- an artifact that has not been published yet, and
- a network or proxy problem

both surface as a **Sonatype** error. Neither message means what it appears to, and the repository named in it is not the one that matters.

The skill now gives the control that separates them — re-resolve a version known to exist:

```bash
mvn dependency:get -Dartifact=com.github.cfmleditor:cfml.parsing:2.15.2-SNAPSHOT
```

If the known-good version fails identically, the environment is the problem and the run says nothing about publication. Two of the three evaluation runs did exactly this unprompted; it is the difference between "I could not verify" and "the version does not exist".

## Two grep decoys and a generated file

- `commons-io:2.15.1` in `build.gradle` matches a naive `2\.15\.` search and is unrelated
- the tracked `pom.xml.versionsBackup` still pins a dead `2.6.0` under the old `com.github.cfparser` groupId — no build reads it, but it turns up every time someone greps for versions here
- `CHANGELOG.md` needs no edit: it is generated from git history by the `gitChangelog` task (`build.gradle:190`), so a hand-written entry is overwritten on the next run

All four claims verified against the working tree rather than taken from the run reports.

## Context

Across three tasks and three arms — skill, `CLAUDE.md` only, bare repo — every arm scored the same on file-level checks. This skill's one demonstrated contribution was reliably driving the upstream-publication check, which is the step that left this repo pinned to a five-month-stale artifact earlier. These edits make the failure modes around that step legible instead of adding more instruction.

Documentation only. No source, build, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_