### PR TITLE
Bump cfparser to 2.16.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ repositories {
     }
 }
 dependencies {
-    implementation 'com.github.cfmleditor:cfml.parsing:2.15.2-SNAPSHOT'
+    implementation 'com.github.cfmleditor:cfml.parsing:2.16.0-SNAPSHOT'
     implementation 'commons-cli:commons-cli:1.2'
     implementation 'ro.fortsoft.pf4j:pf4j:0.6'
     implementation 'org.apache.ant:ant:1.10.14'

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.proc>none</maven.compiler.proc>
 
-		<cfparser.version>2.15.2-SNAPSHOT</cfparser.version>
+		<cfparser.version>2.16.0-SNAPSHOT</cfparser.version>
 		<jackson.version>2.18.6</jackson.version>
 		<slf4j.version>1.7.21</slf4j.version>
 	</properties>


### PR DESCRIPTION
Picks up the grammar work merged upstream since `2.15.2-SNAPSHOT`.

`2.15.2-SNAPSHOT` was published on 10 August and carried only the Java 21 baseline — none of the parser changes after it. `2.16.0-SNAPSHOT` was published today from [cfparser `78a5f6b`](https://github.com/cfmleditor/cfparser/commit/78a5f6b5910c3c43e3fc20b6d4bdfe7a56a35bce), with all three artifacts confirmed uploaded.

## Both declarations moved

| File | Line |
|---|---|
| `pom.xml` | `<cfparser.version>2.16.0-SNAPSHOT</cfparser.version>` |
| `build.gradle` | `implementation 'com.github.cfmleditor:cfml.parsing:2.16.0-SNAPSHOT'` |

Gradle is what CI runs, so a Maven-only bump is the worse half to miss — tests would pass locally while CI kept compiling against the old artifact.

## Java baseline needs no change

cfparser is on `maven.compiler.release` 21 and CFLint is already on 21 in all four places (`pom.xml` source/target, the Gradle toolchain, and both workflow `java-version` settings). Nothing to do.

## This is a recompile, not a jar swap

Upstream added a large number of lexer tokens — cfparser's lexer went from 193 to 298 — and ANTLR renumbers every token constant when that happens. `isExpectedToken(CFSCRIPTParser.SEMICOLON)` inlines that constant into CFLint's bytecode as a `static final int`, so a stale build asks about a different token and misclassifies rather than failing loudly. A clean build is required, which is what was run here.

## What upstream changed

Behaviour that may show up in linting results:

- **Elvis precedence** corrected — `?:` had the highest binary precedence and now sits where the ternary it abbreviates does, so parse trees differ for `?:` mixed with another operator
- **Arrow functions** now build a real AST; `(a, b) => a + b` previously produced the identifier chain `a.ba + b`
- **Component functions** are now returned in source order
- New syntax accepted: array slicing, `instanceOf`, interleaved function modifiers, script-syntax tags, inline component definitions, Lucee extensions

## Verification

Maven, locally:

```
[WARNING] Tests run: 675, Failures: 0, Errors: 0, Skipped: 4
[INFO] BUILD SUCCESS

$ mvn -o dependency:tree -Dincludes=com.github.cfmleditor
\- com.github.cfmleditor:cfml.parsing:jar:2.16.0-SNAPSHOT:compile
   \- com.github.cfmleditor:cfml.dictionary:jar:2.16.0-SNAPSHOT:compile
```

That run resolved from a **locally installed** `2.16.0-SNAPSHOT`, built from the same commit that was published — the bits are the same, but it did not exercise the GitHub Packages resolution path. `./gradlew build` could not run in that environment either: the toolchain pins `JvmVendorSpec.ADOPTIUM`, no Temurin JDK was present, and foojay could not download one through the proxy.

CI covers both gaps. All three Gradle jobs are green, having resolved `2.16.0-SNAPSHOT` from GitHub Packages and rebuilt from scratch (`no cached configuration is available`, `10 actionable tasks: 10 executed`, with `compileJava` and `compileTestJava` both running).

### On the SNAPSHOT cache

Gradle caches a changing module for 24 hours, which normally means a CI run soon after an upstream **republish** can compile against the previous artifact and pass. That does not apply here: `2.16.0-SNAPSHOT` is a new coordinate that never existed before today, so there was no cached copy to serve, and unresolvable coordinates fail the build rather than passing it. This green did exercise the new parser.