### PR TITLE
Publish 1.5.15-SNAPSHOT, and let the publish workflow be dispatched

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ name: Publish package to GitHub Packages
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Mon, 18 Mar 2024 11:40:59 +1000
 org.gradle.configuration-cache=true
 group=com.github.cfmleditor
-version=1.5.14
+version=1.5.15-SNAPSHOT
 name=cflint
 release=false
 snapshot=true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.cfmleditor</groupId>
 	<artifactId>cflint</artifactId>
-	<version>1.5.14</version>
+	<version>1.5.15-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>cflint</name>


### PR DESCRIPTION
Makes the cfparser grammar work from #56 available as a published artifact.

## Why

`master` sat on `1.5.14` — the released version — so there was no snapshot coordinate for anyone to consume. #56 bumped cfparser to `2.16.0-SNAPSHOT` and merged, but nothing downstream of CFLint can see those parser fixes without building CFLint from source.

`publish.yml` triggered only on `release: created`, so a snapshot could not be published at all without cutting a release. `workflow_dispatch` is what cfparser's publish workflow already allows, and it makes snapshot publishing possible without minting a version tag.

## Changes

| File | Change |
|---|---|
| `pom.xml` | `1.5.14` → `1.5.15-SNAPSHOT` |
| `gradle.properties` | `1.5.14` → `1.5.15-SNAPSHOT` |
| `.github/workflows/publish.yml` | added `workflow_dispatch:` |

Only two version locations here, both confirmed by grep.

## Verification

- **675** tests
- `mvn deploy` against a local file repository produces the artifacts, routed through `maven-deploy-plugin`:

```
[INFO] --- deploy:3.1.2:deploy (default-deploy) @ cflint ---

cflint-1.5.15-20260813.080005-1.jar
cflint-1.5.15-20260813.080005-1-all.jar
cflint-1.5.15-20260813.080005-1.pom
```

## On nexus-staging

cfparser had a bug ([cfmleditor/cfparser#58](https://github.com/cfmleditor/cfparser/issues/58)) where `nexus-staging-maven-plugin` with `<extensions>true</extensions>` replaced the deploy lifecycle and made non-SNAPSHOT publishing impossible. The same plugin is in this pom, so it is worth stating plainly that **CFLint does not have that bug**: here it sits inside the `deploy` profile (`activeByDefault=false`), not `<build><plugins>`, so a plain `mvn deploy` never activates it. The deploy log above confirms it — `default-deploy`, not `injected-nexus-deploy`. Release publishing on this side already works; `1.5.14` published green in May.

## Not addressed here

`maven-source-plugin` and `maven-javadoc-plugin` are also inside the `deploy` profile, so published CFLint artifacts carry no sources or javadoc — the same gap as [cfmleditor/cfparser#60](https://github.com/cfmleditor/cfparser/issues/60), which was just fixed upstream. Out of scope for this PR; happy to file it separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_