### PR TITLE
Bump foojay-resolver-convention to 1.0.0 for Gradle 9.6.1 compatibility

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 rootProject.name = 'cflint'


### PR DESCRIPTION
## Summary
- `settings.gradle` pinned `org.gradle.toolchains.foojay-resolver-convention` to `0.8.0`, which is incompatible with Gradle 9.6.1.
- That plugin version's toolchain-distribution class references `JvmVendorSpec.IBM_SEMERU`, a field that doesn't exist on Gradle 9.6.1's `JvmVendorSpec`. Any time toolchain resolution runs, it fails with `NoSuchFieldError` wrapped in `NoClassDefFoundError`/`ExceptionInInitializerError`, which aborts project configuration before the build graph is even calculated — so no task can run.
- Bumping to `1.0.0` resolves it; that's the version this plugin's API actually lines up with on Gradle 9.6.1.

## Test plan
- [x] `./gradlew build` (compile + test + jar) runs cleanly on Gradle 9.6.1 with a real JDK 21 toolchain available locally.
- [x] Confirmed the failure disappears specifically due to the version bump (reproduced the `NoSuchFieldError` root cause with `--stacktrace` before the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)