### PR TITLE
Authenticate the publish workflow with the built-in Actions token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+      # The built-in Actions token, not a PAT. It covers both halves of this job: reading
+      # cfml.parsing from cfmleditor/cfparser, whose packages are public and so accept any
+      # valid token, and writing cflint to this repository, which the packages: write
+      # permission above grants. gradle.yml already resolves cfparser this way. The
+      # GH_USERNAME/GH_TOKEN pair this replaced authenticated in May and returns 401 now,
+      # which is what an expired PAT looks like.
       - name: Configure Maven for GitHub Packages
         run: |
           mkdir -p $HOME/.m2
@@ -31,8 +37,8 @@ jobs:
             <servers>
               <server>
                 <id>github</id>
-                <username>${{ secrets.GH_USERNAME }}</username>
-                <password>${{ secrets.GH_TOKEN }}</password>
+                <username>${{ github.actor }}</username>
+                <password>${{ github.token }}</password>
               </server>
             </servers>
           </settings>


### PR DESCRIPTION
Fixes the failure in [run 31680440548](https://github.com/cfmleditor/CFLint/actions/runs/31680440548), the first dispatched publish after #57.

## What happened

The run died in `mvn -B package` and never reached the deploy step:

```
Could not transfer artifact com.github.cfmleditor:cfml.parsing:pom:2.16.0-SNAPSHOT
from/to github (https://maven.pkg.github.com/cfmleditor/cfparser):
status code: 401, reason phrase: Unauthorized (401)
```

The 401 is on **reading cfparser**, not on publishing CFLint. #57 itself was fine — the version bump and the `workflow_dispatch` trigger both did exactly what they were meant to.

## Why the credentials are the cause

The `settings.xml` this workflow generates authenticated with `GH_USERNAME` / `GH_TOKEN`. That pair worked as recently as May: `1.5.14` published green while resolving cfparser `2.15.0-SNAPSHOT` from the same registry, which also requires authentication. It 401s now. An expired PAT looks precisely like this.

Meanwhile `gradle.yml` resolves the *same artifact* with the built-in `GITHUB_TOKEN` and is green — including on #57, which is what pinned `2.16.0-SNAPSHOT` in the first place. Two workflows in one repo, same registry, same artifact, different credentials, and only the PAT one fails.

| Workflow | Credential | Result |
|---|---|---|
| `gradle.yml` | `secrets.GITHUB_TOKEN` (built-in) | green |
| `publish.yml` | `secrets.GH_USERNAME` / `GH_TOKEN` (PAT) | **401** |

## The change

`settings.xml` now uses `github.actor` / `github.token`. That covers both halves of the job:

- **Reading cfparser** — its packages are public, and GitHub Packages accepts any valid token for public packages. `gradle.yml` is the standing proof.
- **Writing cflint** — already granted by the `packages: write` permission the job declares.

Net effect is one fewer hand-rotated credential, and nothing else in CI depends on the PAT.

## What I could not verify

I cannot read repository secrets, so "expired PAT" is inference from the 401 plus the May success, not something I confirmed directly. If `GH_TOKEN` exists deliberately — to reach a private package, or to publish somewhere this token cannot — then refreshing it is the right fix and this PR is the wrong one. The evidence for the swap is that `gradle.yml` demonstrably reads cfparser with the built-in token today; if that stops being true, this breaks the same way.

Worth a look before merging, since it changes how publishing authenticates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_