### PR TITLE
Let the Gradle toolchain accept any JDK 21, not only Temurin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ plugins {
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
-        vendor = JvmVendorSpec.ADOPTIUM
     }
     
     withJavadocJar()


### PR DESCRIPTION
One line:

```diff
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
-        vendor = JvmVendorSpec.ADOPTIUM
     }
```

## The problem

`./gradlew build` fails on any machine without Eclipse Temurin specifically, even with a correct JDK 21 present:

```
Cannot find a Java installation on your machine (Linux amd64) matching:
{languageVersion=21, vendor=Eclipse Temurin, implementation=vendor-specific, nativeImageCapable=false}.
Some toolchain resolvers had internal failures:
foojay (Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden").
```

Gradle rejects the installed JDK on vendor, then tries to auto-provision Temurin via foojay. Where that download is unavailable — a restricted network, an air-gapped build box, a CI image without it — the build simply cannot run. Since Gradle is the primary build and what CI runs, that is a hard barrier rather than an inconvenience.

## Why the pin is not load-bearing

Bytecode at a given `languageVersion` is identical across OpenJDK vendors. Temurin, Zulu, Corretto and the distro builds are the same source; the pin constrains *who built the compiler*, not what it emits.

Nothing else in the project agrees with it either:

| Where | Says |
|---|---|
| `pom.xml` | `maven.compiler.source/target = 21`, **no vendor constraint** |
| `.sdkmanrc` | `java=11.0.26-zulu` — Zulu 11, from the Java 11 era |
| `BUILDING.md` | does not mention a JDK vendor |
| `build.gradle` | Temurin 21 |

So the Maven and Gradle builds already disagreed about whether vendor matters, and the project's own SDKMAN file names a different vendor *and* a different major version. The line arrived inside [`81f2962f`](https://github.com/cfmleditor/CFLint/commit/81f2962fe08626e35ac63b95d82b5977d76490dd), a thirty-file "Performance tweaks and Update Gradle, GraalVM" commit, rather than as a decision of its own.

## CI is unaffected

`gradle.yml` installs Temurin through `actions/setup-java` with `distribution: 'temurin'`. Runners get exactly the JDK they did before. Reproducibility comes from the workflow pinning a distribution, not from the toolchain rejecting every other one — and the workflow keeps doing that.

`native-release.yml` runs its own JDK 25 for GraalVM and does not use this toolchain.

## Verification

On Ubuntu OpenJDK 21.0.10 — the exact JDK the pin rejected:

```
BUILD SUCCESSFUL
10 actionable tasks: 10 executed

tests=675 failures=0 errors=0 skipped=4
```

Full suite through Gradle, matching the Maven run. Before this change the same command could not get past configuration.

## Noted, not changed

`.sdkmanrc` pinning `11.0.26-zulu` is stale by two major versions and will hand a contributor using SDKMAN a JDK that cannot build this project at all. Left alone deliberately so this PR stays one line — worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_