### PR TITLE
Pin cfparser to the released 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ repositories {
     }
 }
 dependencies {
-    implementation 'com.github.cfmleditor:cfml.parsing:2.16.0-SNAPSHOT'
+    implementation 'com.github.cfmleditor:cfml.parsing:2.16.0'
     implementation 'commons-cli:commons-cli:1.2'
     implementation 'ro.fortsoft.pf4j:pf4j:0.6'
     implementation 'org.apache.ant:ant:1.10.14'

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,6 @@ buildscript {
         }
         maven {
             url = "https://maven.pkg.github.com/cfmleditor/cfparser"
-            mavenContent {
-                snapshotsOnly()
-            }
             credentials {
                 username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
                 password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
@@ -108,9 +105,6 @@ repositories {
     }
     maven {
         url = "https://maven.pkg.github.com/cfmleditor/cfparser"
-        mavenContent {
-            snapshotsOnly()
-        }
         credentials {
             username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
             password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.proc>none</maven.compiler.proc>
 
-		<cfparser.version>2.16.0-SNAPSHOT</cfparser.version>
+		<cfparser.version>2.16.0</cfparser.version>
 		<jackson.version>2.18.6</jackson.version>
 		<slf4j.version>1.7.21</slf4j.version>
 	</properties>


### PR DESCRIPTION
Moves off `2.16.0-SNAPSHOT` onto the fixed `2.16.0`, [published](https://github.com/cfmleditor/cfparser/actions/runs/31760482325) from cfparser `78b45f0`.

## Why it matters here

`2.16.0-SNAPSHOT` was republished several times with different content while the parser work landed. Gradle treats a `-SNAPSHOT` as a changing module and caches it for 24 hours, so a green CI run shortly after a republish could compile against the previous jar — which made "CI is green" and "CI exercised the new parser" two different claims, and I had to keep saying so.

A released coordinate cannot change underneath a build. That ambiguity is gone.

## What arrives with it

`2.16.0` is the first non-SNAPSHOT cfparser has ever published, and it carries everything from this round of parser work, including the fixes behind #50 and #52:

- `component { static x = 1; }` no longer throws NullPointerException — that one aborted the whole file, so CFLint reported `PARSE_ERROR` and no results at all
- Access modifiers accepted inside a `static { }` block
- `::` and `?.` survive decompile instead of collapsing to `.`
- Arrow functions build a real AST, so they no longer silence every rule in a file
- Sources and javadoc jars are attached for the first time, so IDE source attachment works

## Both declarations moved

| File | |
|---|---|
| `pom.xml` | `<cfparser.version>2.16.0</cfparser.version>` |
| `build.gradle` | `implementation 'com.github.cfmleditor:cfml.parsing:2.16.0'` |

Gradle is what CI runs, so a Maven-only bump would pass locally while CI compiled against the old artifact.

## Verification

```
[WARNING] Tests run: 675, Failures: 0, Errors: 0, Skipped: 4
[INFO] BUILD SUCCESS

$ mvn -o dependency:tree -Dincludes=com.github.cfmleditor
\- com.github.cfmleditor:cfml.parsing:jar:2.16.0:compile
   \- com.github.cfmleditor:cfml.dictionary:jar:2.16.0:compile
```

The parser was installed locally from the exact commit that was released (`78b45f0`) rather than an earlier build, so the tests ran against the same content that is in GitHub Packages. The Java baseline needs no change — cfparser and CFLint are both on 21.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_