### PR TITLE
Release 1.5.15

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Mon, 18 Mar 2024 11:40:59 +1000
 org.gradle.configuration-cache=true
 group=com.github.cfmleditor
-version=1.5.15-SNAPSHOT
+version=1.5.15
 name=cflint
 release=false
 snapshot=true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.cfmleditor</groupId>
 	<artifactId>cflint</artifactId>
-	<version>1.5.15-SNAPSHOT</version>
+	<version>1.5.15</version>
 	<packaging>jar</packaging>
 
 	<name>cflint</name>


### PR DESCRIPTION
Moves the two version locations off SNAPSHOT.

## Why now

`1.5.14`, the last release, pins cfparser `2.15.0-SNAPSHOT` — a parser from **March**. Everything fixed since exists only on master, so **anyone using a released CFLint still hits the reported behaviour in #50 and #52 despite both being closed.**

This release carries cfparser `2.16.0`, which fixes them:

| | |
|---|---|
| **#52** | Arrow functions build a real AST. Previously `(a, b) => a + b` produced the identifier chain `a.ba + b`, which derailed the walk and silenced *every* rule in the file. |
| **#50** | Component-level `static x = 1;` no longer throws NullPointerException, which used to abort the whole file — `PARSE_ERROR`, no results. |
| **#50** | Access modifiers accepted inside a `static { }` block, and the block is no longer discarded from the AST. |
| **#50** | `::` and `?.` survive decompile instead of collapsing to `.`. `a?.b` becoming `a.b` changed meaning — one yields null where the other throws. |

Also inherited: array slicing, `instanceOf`, script-syntax tags, Lucee extensions, inline component definitions, corrected `cfproperty`/`cfparam` attribute sets, and elvis-operator precedence.

## Verified against the released parser

`#52` re-checked with a clean build resolving `cfml.parsing:2.16.0` — the reporter's exact component, with and without the arrow function:

```
findings: 18 vs 18, identical apart from the component's own name
MISSING_VAR / ARG_VAR_CONFLICT / AVOID_USING_STRUCTNEW all present
```

- **675** tests under Maven **and** Gradle
- `mvn deploy` against a local file repository routes through `maven-deploy-plugin` and produces `cflint-1.5.15.jar`, `cflint-1.5.15-all.jar` and the pom

## Publishing

`publish.yml` fires on `release: created`, and since #57 also on `workflow_dispatch`. Unlike cfparser's `2.16.0`, nothing has been published at `1.5.15`, so there is no duplicate-publish hazard either way.

`nexus-staging` sits inside the `deploy` profile here rather than the main build, so it does not hijack the deploy phase — release publishing on this side already works, as `1.5.14` demonstrated.

## Known gap, not fixed here

The Maven deploy attaches no sources or javadoc jars — both plugins live in the `deploy` profile the publish workflow never activates. Same cause as the cfparser issue fixed in its #61. Gradle builds them; Maven does not publish them. Out of scope for a version bump, and worth its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_