### PR TITLE
Back to 1.5.15-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Mon, 18 Mar 2024 11:40:59 +1000
 org.gradle.configuration-cache=true
 group=com.github.cfmleditor
-version=1.5.15
+version=1.5.15-SNAPSHOT
 name=cflint
 release=false
 snapshot=true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.cfmleditor</groupId>
 	<artifactId>cflint</artifactId>
-	<version>1.5.15</version>
+	<version>1.5.15-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>cflint</name>


### PR DESCRIPTION
Returns the two version locations to `1.5.15-SNAPSHOT`.

#64 moved master to the fixed `1.5.15` in preparation for a release. That release is not being cut — publishing as a snapshot instead — so master goes back to the snapshot and `1.5.15` stays available for whenever a release happens.

**Nothing was ever published at `1.5.15`**, so nothing is orphaned and there is no duplicate-publish hazard left behind.

The cfparser `2.16.0` pin is unchanged, so the snapshot still carries the parser fixes behind #50 and #52.

## Verification

675 tests.

Note for anyone reproducing: `mvn -o clean test` currently fails here, unrelated to this change — master picked up Jackson `2.18.9` via #60/#61 and it is not in a pre-existing local repository, so the offline flag cannot resolve it. Online, it passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_