### PR TITLE
Track the cfparser snapshot from CFLint's snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ repositories {
     }
 }
 dependencies {
-    implementation 'com.github.cfmleditor:cfml.parsing:2.16.0'
+    implementation 'com.github.cfmleditor:cfml.parsing:2.16.1-SNAPSHOT'
     implementation 'commons-cli:commons-cli:1.2'
     implementation 'ro.fortsoft.pf4j:pf4j:0.6'
     implementation 'org.apache.ant:ant:1.10.14'

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.proc>none</maven.compiler.proc>
 
-		<cfparser.version>2.16.0</cfparser.version>
+		<cfparser.version>2.16.1-SNAPSHOT</cfparser.version>
 		<jackson.version>2.18.9</jackson.version>
 		<slf4j.version>1.7.21</slf4j.version>
 	</properties>


### PR DESCRIPTION
Moves both pins from the released `2.16.0` to `2.16.1-SNAPSHOT`.

## Why

CFLint's snapshot was pinned to a **released** parser. Snapshots should track snapshots: a development build that consumes a fixed dependency cannot surface upstream regressions until the next release, which is the opposite of what a snapshot is for. With this, parser changes reach CFLint's CI as they land.

## Ordering

`2.16.1-SNAPSHOT` had never been published — cfparser master moved to it in #71 and no publish had run since. So it went out first, from `d4f8fb0`:

```
coldfusion-parser .................................. SUCCESS
cfml.dictionary .................................... SUCCESS
cfml.parsing ....................................... SUCCESS
```

Without that, this pin would not resolve.

## Both declarations moved

| File | |
|---|---|
| `pom.xml` | `<cfparser.version>2.16.1-SNAPSHOT</cfparser.version>` |
| `build.gradle` | `implementation 'com.github.cfmleditor:cfml.parsing:2.16.1-SNAPSHOT'` |

## Verification

**675 tests under both Maven and Gradle.** Both, deliberately — the last pin change passed under Maven and still failed CI, because `build.gradle` carried a `mavenContent { snapshotsOnly() }` restriction that `pom.xml` did not. Gradle is what CI runs, so a Maven-only result proves less than it appears to.

```
$ mvn -o dependency:tree -Dincludes=com.github.cfmleditor
\- com.github.cfmleditor:cfml.parsing:jar:2.16.1-SNAPSHOT:compile
   \- com.github.cfmleditor:cfml.dictionary:jar:2.16.1-SNAPSHOT:compile
```

Worth noting `snapshotsOnly()` was removed in #63 for the release pin — so this snapshot pin would have resolved under the old configuration too, but the release one no longer needs to.

## What this does not change

`2.16.1-SNAPSHOT` currently contains **nothing** beyond `2.16.0` except the version bump itself, so behaviour is identical today. This is about where future parser work arrives, not about picking up anything new.

## Separate decision, when 1.5.15 is cut

The release pin should move back to a fixed cfparser version. Shipping a release that depends on a moving snapshot means the released artifact's behaviour is not reproducible from its coordinates. Not addressed here, since no release is being cut.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzpZFd4rnE1Yi2sVHAji35)_